### PR TITLE
feat(agents): generate homepage markdown for AI agent consumption

### DIFF
--- a/.github/workflows/generate-homepage-markdown.yml
+++ b/.github/workflows/generate-homepage-markdown.yml
@@ -1,0 +1,55 @@
+name: Generate homepage markdown
+
+# The GOFS homepage (overrides/home.html + overrides/locales/*.html) is a
+# Jinja2 template, unlike every other page on the site, which is authored
+# directly in markdown. This workflow builds the site, converts the
+# rendered homepage HTML (per locale) to markdown, and commits the result
+# back to the PR branch so agents requesting text/markdown get real
+# content instead of empty frontmatter.
+
+on:
+  pull_request:
+    paths:
+      - "overrides/home.html"
+      - "overrides/locales/*.html"
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install conversion script dependencies
+        working-directory: scripts
+        run: npm install
+
+      - name: Convert homepage HTML to markdown
+        run: node scripts/html-to-markdown.js
+
+      - name: Commit generated markdown
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: regenerate homepage markdown for agents"
+          file_pattern: "docs/*/index.generated.md"

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# GOFS - General On-Demand Feed Specification
+
+> GOFS is an open source, community-driven data standard for traveler-facing information about demand-responsive transportation. It provides real-time information about point-to-point, demand-responsive service within a zone, using a lightweight, easy-to-implement format. Maintained by MobilityData.
+
+## Resources
+- [GOFS specification (GitHub)](https://github.com/MobilityData/GOFS)
+- [Homepage](https://gofs.org/)
+
+## Related standards
+- [GTFS](https://gtfs.org/) — fixed-route transit
+- [GTFS-Flex](https://gtfs.org/community/extensions/flex/) — demand-responsive transit with deviation or fixed stops (static only)
+- [GBFS](https://gbfs.org/) — self-service shared vehicles (bikeshare, carshare)
+
+## When to use GOFS
+- Taxi / ridehail: GOFS
+- Zone-based microtransit: GOFS (includes real-time) or GTFS-Flex (static only)
+- Predefined routes with deviation: GTFS-Flex
+- Fixed stops: GTFS-Flex
+- Fixed-route transit: GTFS
+- Self-service shared vehicles: GBFS
+
+## Community
+- [#GOFS Slack channel (MobilityData Slack)](https://share.mobilitydata.org/slack)

--- a/scripts/html-to-markdown.js
+++ b/scripts/html-to-markdown.js
@@ -1,0 +1,107 @@
+// Converts the built homepage HTML (per locale) into a markdown file for
+// agent consumption, since overrides/home.html + overrides/locales/*.html
+// is a Jinja2 template with no plain-markdown equivalent - unlike every
+// other page on the site, which is authored directly in markdown.
+//
+// Reads: site/index.html, site/<locale>/index.html (mkdocs build output)
+// Writes: docs/<locale>/index.generated.md
+//
+// Assumption (confirm against mkdocs.yml if this changes): docs source is
+// organized as docs/<locale>/..., with "en" as the default/root locale.
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+const TurndownService = require("turndown");
+
+const SITE_DIR = path.join(process.cwd(), "site");
+const DOCS_DIR = path.join(process.cwd(), "docs");
+
+const turndown = new TurndownService({
+  headingStyle: "atx",
+  bulletListMarker: "-"
+});
+
+// Strip elements that are chrome, not content: nav, header, footer, scripts,
+// styles, and the cookie-consent dialog.
+const STRIP_SELECTORS = [
+  "header.md-header",
+  "nav.md-nav",
+  ".md-sidebar",
+  "footer.md-footer",
+  "script",
+  "style",
+  "link",
+  ".md-consent",
+  ".md-dialog",
+  "button.md-top"
+];
+
+function extractLocaleDirs() {
+  const locales = [{ locale: "en", dir: SITE_DIR }];
+
+  if (!fs.existsSync(SITE_DIR)) {
+    throw new Error(`Build output not found at ${SITE_DIR}. Run "mkdocs build" first.`);
+  }
+
+  for (const entry of fs.readdirSync(SITE_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidateIndex = path.join(SITE_DIR, entry.name, "index.html");
+    if (fs.existsSync(candidateIndex)) {
+      locales.push({ locale: entry.name, dir: path.join(SITE_DIR, entry.name) });
+    }
+  }
+
+  return locales;
+}
+
+function convertOne({ locale, dir }) {
+  const htmlPath = path.join(dir, "index.html");
+  if (!fs.existsSync(htmlPath)) {
+    console.warn(`[skip] No index.html for locale "${locale}" at ${htmlPath}`);
+    return;
+  }
+
+  const html = fs.readFileSync(htmlPath, "utf-8");
+  const dom = new JSDOM(html);
+  const document = dom.window.document;
+
+  for (const selector of STRIP_SELECTORS) {
+    document.querySelectorAll(selector).forEach((el) => el.remove());
+  }
+
+  // Main content lives inside <main class="md-main">; fall back to <body>
+  // if that structure ever changes.
+  const main = document.querySelector("main.md-main") || document.body;
+
+  const markdown = turndown.turndown(main.innerHTML).trim();
+
+  const title = document.querySelector("title")?.textContent?.trim() || "";
+
+  const frontmatter = [
+    "---",
+    "template: home.html",
+    `title: ${title}`,
+    "# This file is auto-generated from overrides/home.html +",
+    "# overrides/locales/" + locale + ".html - do not edit directly.",
+    "---",
+    ""
+  ].join("\n");
+
+  const outDir = path.join(DOCS_DIR, locale);
+  const outPath = path.join(outDir, "index.generated.md");
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(outPath, frontmatter + "\n" + markdown + "\n");
+
+  console.log(`[ok] Wrote ${outPath}`);
+}
+
+function main() {
+  const locales = extractLocaleDirs();
+  for (const entry of locales) {
+    convertOne(entry);
+  }
+}
+
+main();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gofs-homepage-md-generator",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Converts the built GOFS homepage HTML (per locale) into markdown for AI agent consumption.",
+  "main": "html-to-markdown.js",
+  "dependencies": {
+    "jsdom": "^24.0.0",
+    "turndown": "^7.2.0"
+  }
+}


### PR DESCRIPTION
The homepage (`overrides/home.html` + `overrides/locales/*.html`) is templated HTML with no hand-authored markdown source, unlike every other page on the site. This adds a workflow that builds the site and converts the rendered homepage HTML to markdown per locale.

- add `.github/workflows/generate-homepage-markdown.yml`: runs on PRs touching the homepage template or locale files, builds the site, and commits the generated markdown back to the PR branch
- add `scripts/html-to-markdown.js`: converts `site/<locale>/index.html` to `docs/<locale>/index.generated.md` using turndown
- add `scripts/package.json`: turndown and `jsdom` dependencies