### PR TITLE
chore: add robots.txt with AI crawler policy

### DIFF
--- a/docs/en/robots.txt
+++ b/docs/en/robots.txt
@@ -1,0 +1,39 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=no
+Allow: /


### PR DESCRIPTION
## Summary
Adds `docs/en/robots.txt`, which the English build copies verbatim to the site root (`generated/robots.txt` → `gtfs.org/robots.txt`).

- Lists the major AI/search crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, Google-Extended, Claude-Web, ClaudeBot, anthropic-ai, CCBot, PerplexityBot, Amazonbot, Bytespider, Applebot-Extended) each with `Allow: /`.
- Catch-all `User-agent: *` with `Content-Signal: ai-train=yes, search=yes, ai-input=no` and `Allow: /`.

## Why here (not per-language)
`robots.txt` is only honored at the site root. Only the English config builds to `generated/` (the root); every other language builds to `generated/<lang>/`, where a robots.txt would be ignored by crawlers. So a single file under `docs/en/` is the correct and sufficient placement.

## Note for reviewers
The `Content-Signal` was intentionally set to `ai-train=yes` to stay consistent with the allow-all rules. Confirm the allow-all training posture is the intended policy.